### PR TITLE
Update OAuth1HmacSha1HttpMessageHandler.cs

### DIFF
--- a/src/DotNetOpenAuth.OAuth.Consumer/OAuth/OAuth1HmacSha1HttpMessageHandler.cs
+++ b/src/DotNetOpenAuth.OAuth.Consumer/OAuth/OAuth1HmacSha1HttpMessageHandler.cs
@@ -50,7 +50,7 @@ namespace DotNetOpenAuth.OAuth {
 		/// The signature.
 		/// </returns>
 		protected override byte[] Sign(byte[] signedPayload) {
-			using (var algorithm = HMACSHA1.Create()) {
+			using (var algorithm = HMACSHA1.Create("HMACSHA1")) {
 				algorithm.Key = Encoding.ASCII.GetBytes(this.GetConsumerAndTokenSecretString());
 				return algorithm.ComputeHash(signedPayload);
 			}


### PR DESCRIPTION
The default implementation of this cryptography algorithm is not supported in .NET Core 2.0 - 3.1 and .NET 5 and later
So we need to specify an algorithm name, instead.
https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.hmac.create